### PR TITLE
Fix: change default in basellm_tool to include chain

### DIFF
--- a/backend/app/app/config/tools.yml
+++ b/backend/app/app/config/tools.yml
@@ -48,8 +48,6 @@ library:
         content: |-
           Example Input: \"User question: What are all the albums by ACDC?\"
           Example Output: \"Did you know that the band AC/DC was founded in 1973\"
-    additional:
-      human_message_only: true
   summarizer_tool:
     description: >-
       Summarizer tool to reduce the length of a text to a few sentences.
@@ -361,8 +359,6 @@ library:
       - name: output
         content: |-
           I'm not sure which action to take. Can you clarify your question such that it is easier to understand what action I should
-    additional:
-      human_message_only: false
   chain_tool:
     description: Nested meta-agent tool
     prompt_inputs: []

--- a/backend/app/app/config/tools.yml
+++ b/backend/app/app/config/tools.yml
@@ -24,8 +24,6 @@ library:
         content: |-
           Example Input: \"User question: Could you find a list of tracks that Daan Peeters has purchased?\"
           Example Output: \"Daan Peters has purchased a total of X tracks, please see a list below...\"
-    additional:
-      human_message_only: false
   entertainer_tool:
     description: >-
       Entertainer tool to write a small concise output from memory while the information is loading.

--- a/backend/app/app/config/tools.yml
+++ b/backend/app/app/config/tools.yml
@@ -24,6 +24,8 @@ library:
         content: |-
           Example Input: \"User question: Could you find a list of tracks that Daan Peeters has purchased?\"
           Example Output: \"Daan Peters has purchased a total of X tracks, please see a list below...\"
+    additional:
+      human_message_only: false
   entertainer_tool:
     description: >-
       Entertainer tool to write a small concise output from memory while the information is loading.
@@ -48,6 +50,8 @@ library:
         content: |-
           Example Input: \"User question: What are all the albums by ACDC?\"
           Example Output: \"Did you know that the band AC/DC was founded in 1973\"
+    additional:
+      human_message_only: true
   summarizer_tool:
     description: >-
       Summarizer tool to reduce the length of a text to a few sentences.
@@ -359,6 +363,8 @@ library:
       - name: output
         content: |-
           I'm not sure which action to take. Can you clarify your question such that it is easier to understand what action I should
+    additional:
+      human_message_only: false
   chain_tool:
     description: Nested meta-agent tool
     prompt_inputs: []

--- a/backend/app/app/services/chat_agent/tools/ExtendedBaseTool.py
+++ b/backend/app/app/services/chat_agent/tools/ExtendedBaseTool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any, List, Optional
 
+from box import Box
 from langchain.base_language import BaseLanguageModel
 from langchain.callbacks.manager import AsyncCallbackManagerForToolRun, CallbackManagerForToolRun
 from langchain.schema import BaseMessage
@@ -36,6 +37,8 @@ class ExtendedBaseTool(BaseTool):
     system_context_refinement: Optional[str] = None
 
     image_description_prompt: Optional[str] = None
+
+    additional: Optional[Box] = None
 
     @classmethod
     def from_config(

--- a/backend/app/app/services/chat_agent/tools/library/basellm_tool/basellm_tool.py
+++ b/backend/app/app/services/chat_agent/tools/library/basellm_tool/basellm_tool.py
@@ -72,7 +72,7 @@ class BaseLLM(ExtendedBaseTool):
             args[0],
         )
 
-        if self.additional.get("human_message_only", False):
+        if self.additional is not None and self.additional.get("human_message_only", False):
             # Only use the latest human message
             query = ToolInputSchema.parse_raw(query).latest_human_message
 

--- a/backend/app/app/services/chat_agent/tools/library/basellm_tool/basellm_tool.py
+++ b/backend/app/app/services/chat_agent/tools/library/basellm_tool/basellm_tool.py
@@ -67,12 +67,12 @@ class BaseLLM(ExtendedBaseTool):
         **kwargs: Any,
     ) -> str:
         """Use the tool asynchronously."""
-        tool_input = kwargs.get(
+        tool_input_str = kwargs.get(
             "query",
             args[0],
         )
 
-        query = standard_query_format(tool_input)
+        query = standard_query_format(ToolInputSchema.parse_raw(tool_input_str))
 
         try:
             messages = [

--- a/backend/app/app/services/chat_agent/tools/library/basellm_tool/basellm_tool.py
+++ b/backend/app/app/services/chat_agent/tools/library/basellm_tool/basellm_tool.py
@@ -47,6 +47,7 @@ class BaseLLM(ExtendedBaseTool):
             prompt_message=config.prompt_message.format(**{e.name: e.content for e in config.prompt_inputs}),
             system_context=config.system_context.format(**{e.name: e.content for e in config.prompt_inputs}),
             name=kwargs.get("name", "basellm_tool"),
+            additional=config.additional,
         )
 
     def _run(
@@ -70,8 +71,10 @@ class BaseLLM(ExtendedBaseTool):
             "query",
             args[0],
         )
-        # Only use the latest human message
-        query = ToolInputSchema.parse_raw(query).latest_human_message
+
+        if self.additional.get("human_message_only", False):
+            # Only use the latest human message
+            query = ToolInputSchema.parse_raw(query).latest_human_message
 
         try:
             messages = [


### PR DESCRIPTION
This PR changes the behaviour of BaseLLM tools including the default expert_tool, clarifier_tool, and (optionally) entertainer_tool.

Currently the default routes in the Chinook demo use `expert_tool` as a formulation step, but the previous default only uses latest human message so summaries did not refer to retrieved information in intermediate steps or memory.