### PR TITLE
Fix/docker

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS base
+FROM node:18-alpine@sha256:b17bf243e453f407ac0acf47d55fe08ae8b5a63ae3c1bd62f474bd0eb1c4c467 AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml* ./
-RUN yarn global add pnpm && pnpm i --frozen-lockfile
+RUN yarn global add pnpm && pnpm i --no-frozen-lockfile
 
 # Rebuild the source code only when needed
 FROM base AS builder

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,6 @@
     "name": "jheyder",
     "email": "heyder.jakob@bcg.com"
   },
-  "packageManager": "pnpm@8.6.1",
   "scripts": {
     "build": "next build",
     "dev": "next dev",


### PR DESCRIPTION
The FE docker is broken by an upstream change from `node:18-alpine`. The error is related to `pnpm` versions. Here is a quick fix.

- Removed `"packageManager"` from `package.json`
- Changed `pnpm` option to `--no-frozen-lockfile` in `frontend/Dockerfile`
- Pinned based image version for frontend Dockerfile

This is tested to work in MacOS and Linux.